### PR TITLE
removed nav on carousel because we couldn't scroll with the track pad…

### DIFF
--- a/assets/css/main.sass
+++ b/assets/css/main.sass
@@ -40,9 +40,9 @@ h1
   font-family: "Work Sans regular", sans-serif
 
 .title
-  color: rgb(2, 62, 30)
+  color: #042709
 .subtitle
-  color: rgba(6, 59, 14, 0.9)
+  // color: rgba(6, 61, 14, 0.9)
 
 .content
   h3
@@ -67,6 +67,10 @@ div
   .explications
     padding-bottom: 1.5rem
     padding-right: 1.5rem
+
+.container.is-fluid-hero
+  padding-left: 1.5rem
+  padding-right: 1.5rem
 
 .label
   color: #363636
@@ -114,12 +118,16 @@ div
         border-radius: 15px 15px 0 0
 
 //carousel 
-.level-right
-  padding-right: 1.5rem
 
 .arrow
   color: rgba(255, 255, 255, 0.60)
   cursor: pointer
+  position: absolute
+  top: 48%
+  &-left
+    left: 0
+  &-right
+    right: 1.5rem
 
 /* Hide scrollbar for Chrome, Safari and Opera */
 .scroll-ctn::-webkit-scrollbar

--- a/components/5_Photos.vue
+++ b/components/5_Photos.vue
@@ -33,30 +33,20 @@
             </div>
           </div>
         </div>
-        <nav class="level is-mobile is-overlay is-hidden-mobile">
-          <div class="level-left">
-            <div class="level-item">
-              <span class="icon is-large">
-                <font-awesome-icon
-                  class="fas fa-3x arrow"
-                  @click="moveCarousel(-1)"
-                  :icon="['fas', 'chevron-left']"
-                />
-              </span>
-            </div>
-          </div>
-          <div class="level-right">
-            <div class="level-item">
-              <span class="icon is-large">
-                <font-awesome-icon
-                  class="fas fa-3x arrow"
-                  @click="moveCarousel(1)"
-                  :icon="['fas', 'chevron-right']"
-                />
-              </span>
-            </div>
-          </div>
-        </nav>
+        <span class="icon is-large is-hidden-mobile arrow arrow-left">
+          <font-awesome-icon
+            class="fas fa-3x"
+            @click="moveCarousel(-1)"
+            :icon="['fas', 'chevron-left']"
+          />
+        </span>
+        <span class="icon is-large is-hidden-mobile arrow arrow-right">
+          <font-awesome-icon
+            class="fas fa-3x"
+            @click="moveCarousel(1)"
+            :icon="['fas', 'chevron-right']"
+          />
+        </span>
       </div>
     </div>
   </section>

--- a/components/6_ListeMariage.vue
+++ b/components/6_ListeMariage.vue
@@ -32,38 +32,31 @@
             </div>
           </div>
         </div>
-        <nav class="level is-mobile is-overlay is-hidden-mobile">
-          <div class="level-left">
-            <div class="level-item">
-              <span class="icon is-large">
-                <font-awesome-icon
-                  class="fas fa-3x arrow"
-                  @click="moveCarousel(-1)"
-                  :icon="['fas', 'chevron-left']"
-                />
-              </span>
-            </div>
-          </div>
-          <div class="level-right">
-            <div class="level-item">
-              <span class="icon is-large">
-                <font-awesome-icon
-                  class="fas fa-3x arrow"
-                  @click="moveCarousel(1)"
-                  :icon="['fas', 'chevron-right']"
-                />
-              </span>
-            </div>
-          </div>
-        </nav>
-        <div class="explications">
-          <p>
-            Si vous voulez participer à l'achat d'un des cadeaux des images du dessus vous pouvez donner un petit quelque chose dans la cagnotte Paypal ou dans l'urne qui sera présente sur place le 5 décembre
-            <span>🤗</span>
-          </p>
-        </div>
-        <Paypal />
+        <span class="icon is-large is-hidden-mobile arrow arrow-left">
+          <font-awesome-icon
+            class="fas fa-3x"
+            @click="moveCarousel(-1)"
+            :icon="['fas', 'chevron-left']"
+          />
+        </span>
+        <span class="icon is-large is-hidden-mobile arrow arrow-right">
+          <font-awesome-icon
+            class="fas fa-3x"
+            @click="moveCarousel(1)"
+            :icon="['fas', 'chevron-right']"
+          />
+        </span>
       </div>
+    </div>
+
+    <div class="container is-fluid-hero">
+      <div class="explications">
+        <p>
+          Si vous voulez participer à l'achat d'un des cadeaux des images du dessus vous pouvez donner un petit quelque chose dans la cagnotte Paypal ou dans l'urne qui sera présente sur place le 5 décembre
+          <span>🤗</span>
+        </p>
+      </div>
+      <Paypal />
     </div>
   </section>
 </template>


### PR DESCRIPTION
… on Mac as it were overlaying the whole carousel. Put the description at teh end of liste de mariage after the hero body and wrapped it into a custom is-fluid-hero class that has the same padding left right than the hero banner: 24px