### PR TITLE
Fixed spurious language change when clicking on anchor links

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -84,10 +84,16 @@ export default {
           },
         ],
         langDir: 'lang/',
-        detectBrowserLanguage: true,
         defaultLocale: 'fr',
         strategy: 'prefix',
         lazy: true,
+        detectBrowserLanguage: {
+          useCookie: true,
+          cookieDomain: null,
+          cookieKey: 'lang',
+          alwaysRedirect: true,
+          fallbackLocale: 'fr'
+        },
       }],
   ],
 


### PR DESCRIPTION
Now using cookies to keep track of language changes:


```
        detectBrowserLanguage: {
          useCookie: true,
          cookieDomain: null,
          cookieKey: 'lang',
          alwaysRedirect: true,
          fallbackLocale: 'fr'
        },
```

 In nuxt.config.js